### PR TITLE
Fix CMake module path when included as subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(gltext)
 cmake_minimum_required(VERSION 2.8)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${gltext_SOURCE_DIR}/cmake/")
 
 set(HB_SOURCES
     harfbuzz/hb-blob.cc


### PR DESCRIPTION
Hi! This fixes compilation when including as subdirectory. In this case, CMAKE_SOURCE_DIR is the top-level directory.
