### PR TITLE
Unbind any active texture sampler.

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,7 @@ gltext makes some changes to the GL state as it renders. In most applications, t
   * CURRENT_PROGRAM is set to the shared text-drawing shader program
   * ACTIVE_TEXTURE is set to TEXTURE0
   * TEXTURE_BINDING_2D is set to the Font's cache texture
+  * SAMPLER_BINDING is set to 0 for TEXTURE0 (OpenGL 3.3 and higher)
   * UNPACK_ALIGNMENT is set to 1
   * UNPACK_ROW_LENGTH is set to an arbitrary value
 

--- a/gltext.cpp
+++ b/gltext.cpp
@@ -478,7 +478,9 @@ void Font::draw(std::string text) {
 
     gltextActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, self->tex);
-    gltextBindSampler(0, 0);
+    if (gltextBindSampler) {
+        gltextBindSampler(0, 0);
+    }
     gltextBindVertexArray(self->vao);
     gltextUseProgram(FontSystem::instance().prog);
     gltextUniform2i(FontSystem::instance().scale_loc, self->window_w, self->window_h);

--- a/gltext.cpp
+++ b/gltext.cpp
@@ -92,6 +92,7 @@ void main() {\n\
 ";
 
 static PFNGLACTIVETEXTUREPROC gltextActiveTexture;
+static PFNGLBINDSAMPLERPROC gltextBindSampler;
 static PFNGLGENVERTEXARRAYSPROC gltextGenVertexArrays;
 static PFNGLBINDVERTEXARRAYPROC gltextBindVertexArray;
 static PFNGLDELETEVERTEXARRAYSPROC gltextDeleteVertexArrays;
@@ -118,6 +119,7 @@ static PFNGLBINDATTRIBLOCATIONPROC gltextBindAttribLocation;
 
 static void initGlPointers() {
     gltextActiveTexture = (PFNGLACTIVETEXTUREPROC)glPointer("glActiveTexture");
+    gltextBindSampler = (PFNGLBINDSAMPLERPROC)glPointer("glBindSampler");
     gltextGenVertexArrays = (PFNGLGENVERTEXARRAYSPROC)glPointer("glGenVertexArrays");
     gltextBindVertexArray = (PFNGLBINDVERTEXARRAYPROC)glPointer("glBindVertexArray");
     gltextDeleteVertexArrays = (PFNGLDELETEVERTEXARRAYSPROC)glPointer("glDeleteVertexArrays");
@@ -476,6 +478,7 @@ void Font::draw(std::string text) {
 
     gltextActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, self->tex);
+    gltextBindSampler(0, 0);
     gltextBindVertexArray(self->vao);
     gltextUseProgram(FontSystem::instance().prog);
     gltextUniform2i(FontSystem::instance().scale_loc, self->window_w, self->window_h);

--- a/gltext.cpp
+++ b/gltext.cpp
@@ -478,7 +478,7 @@ void Font::draw(std::string text) {
 
     gltextActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, self->tex);
-    if (gltextBindSampler) {
+    if(gltextBindSampler) {
         gltextBindSampler(0, 0);
     }
     gltextBindVertexArray(self->vao);


### PR DESCRIPTION
Make sure that no previously used texture sampler is active for texture unit 0.
